### PR TITLE
keep searching for license files until a license is found

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ module.exports = function(packagePath){
             // Do a case-insensitive match to find files named
             // Readme.md or other variations
             if (potentialFilenames[i].toLowerCase() === files[j].toLowerCase()) {
-                return licenseFromString(fs.readFileSync(path.resolve(packagePath, files[j]), 'utf8'));
+                var license = licenseFromString(fs.readFileSync(path.resolve(packagePath, files[j]), 'utf8'));
+                if (license) return license;
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-license",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Checks the filesystem for potential license files and attempts to detect what they are",
   "main": "index.js",
   "scripts": {
@@ -16,6 +16,10 @@
     "detect"
   ],
   "author": "Duncan Wong <baduncaduncan@gmail.com>",
+  "contributors": [{
+    "name": "Alexander Wunschik",
+    "email": "dev@wunschik.net"
+  }],
   "license": "Apache2",
   "bugs": {
     "url": "https://github.com/AceMetrix/package-license/issues"


### PR DESCRIPTION
The search for a license should be continued if a "potential" file is found but no license could be found in it. In that case _licenseFromString_ returns _undefined_ and the other "potential" files are not checked because the module returns.

For example the filename _license.txt_ is never checked if a _readme_ exists, weather or not the readme include license information.
